### PR TITLE
Adding CORS for metadata request into server config

### DIFF
--- a/.lighttpd.conf
+++ b/.lighttpd.conf
@@ -9,6 +9,7 @@ fastcgi.server += ( "/zoomviewer/iipsrv.fcgi" =>
  	"FILESYSTEM_PREFIX" => "/data/project/zoomviewer/public_html/",
         "LOGFILE" => "/data/project/zoomviewer/iipsrv.log",
         "TMPDIR" => "/data/project/zoomviewer/var/tmp",
+        "CORS" => "*",
         "VERBOSITY" => "1"
       )
   ))


### PR DESCRIPTION
This will make the IIIF service much more usable.

The option has been added to IIPImage on 08/03/2014. See:
https://github.com/ruven/iipsrv/blob/df49d92b7084ddf8f9090272387d086b569cc1dd/ChangeLog#L197

So the only requirement for this to run is having IIPImage compiled from code younger then mentioned date.
